### PR TITLE
feat: create docker publish image action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,29 @@
+name: register-image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: lradhy/hub-discord:latest


### PR DESCRIPTION
## O que foi feito?

- Criada uma action que faz o build e publica a imagem na Dockerhub baseado na criação de novos releases

## O que ainda precisa ser feito

- O mantenedor do projeto deve registrar suas credenciais como secrets:
```sh
DOCKERHUB_USERNAME
DOCKERHUB_TOKEN
```
Closes #42 
